### PR TITLE
Doesn't work on CentOS 6.5

### DIFF
--- a/check_iptables_status.sh
+++ b/check_iptables_status.sh
@@ -49,9 +49,8 @@ function usage()
 	cat <<EOF
 $0 -T <table> -r <min rules>
 	<min rules>	Minimun quantity of rules.
-	<table>		Table to check.  Currently available:
+	<table>		Table to check.
 EOF
-	sed 's%^%\t\t%' /proc/net/ip_tables_names
 	echo
 }
 


### PR DESCRIPTION
sed: can't read /proc/net/ip_tables_names: No such file or directory
